### PR TITLE
GUI & stability improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,21 +3,33 @@ Unofficial Submarine Titans patch
 
 **Requirements**
 * Windows 10 (Windows 7 works but isn't actively tested)
-* Supports Steam v1.0, Retail v1.1 and GOG v1.1
+* Supports Steam/Retail v1.0, Retail v1.1 and GOG v1.1
 
 **Features**
-* Support for native resolution (tested up to 3840x2160)
-* Support for high DPI (Steam; not required for GOG)
+* Support for native resolution ingame (tested up to 3840x2160)
+* Support for high DPI display resolutions (Steam; not required for GOG)
 * Fixes alt-tab crashes (Steam; not required for GOG)
 * Fixes various internal errors (Steam; not required for GOG)
 * Performance boost (Steam; not required for GOG)
-* Windows 7 color fix (Steam; not required for GOG)
+* Windows 7 color fix (Steam; not required for GOG) - not actively tested
 
 **Instructions**
 1. Copy & paste d3drm.dll and subtitans.dll in your Submarine Titans folder.
 2. Open STConfig.exe and select 1280x1024.
 3. Run the game (through ST.exe or Steam).
-4. Install vc_redist.x86.exe ( https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads ) if you're getting MSVCP140.dll errors.
+
+**Q&A**
+Q: Help, I'm getting MSVCP140.dll errors!
+A: Install vc_redist.x86.exe ( https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads ).
+
+Q: How to update Submarine Titans to version 1.1?
+A: https://steamcommunity.com/sharedfiles/filedetails/?id=2129291420
+
+Q: Why is the game running so slow? (Steam/Retail only)
+A: Submarine Titan uses DirectDraw, a deprecated piece of technology from a bygone era. A patch to circumvent DirectDraw is in development.
 
 **Known bugs**
-* 1366*768 does not work correctly
+* 1366*768 does not function correctly, reverts to 1280x768 ingame.
+
+**Uninstall**
+* Deleting SubTitans.dll will disable the ingame patches.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Q: How to update Submarine Titans to version 1.1? \
 A: https://steamcommunity.com/sharedfiles/filedetails/?id=2129291420 \
  \
 Q: Why is the game running so slow? (Steam/Retail only) \
-A: Submarine Titan uses DirectDraw, a deprecated piece of technology from a bygone era. A patch to circumvent DirectDraw is in development. \
+A: Submarine Titan uses DirectDraw, a deprecated piece of technology from a bygone era. A patch to circumvent DirectDraw is in development.
 
 **Known bugs**
 * 1366*768 does not function correctly, reverts to 1280x768 ingame.

--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@ Unofficial Submarine Titans patch
 2. Open STConfig.exe and select 1280x1024.
 3. Run the game (through ST.exe or Steam).
 
-**Q&A**
-Q: Help, I'm getting MSVCP140.dll errors!
-A: Install vc_redist.x86.exe ( https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads ).
-
-Q: How to update Submarine Titans to version 1.1?
-A: https://steamcommunity.com/sharedfiles/filedetails/?id=2129291420
-
-Q: Why is the game running so slow? (Steam/Retail only)
-A: Submarine Titan uses DirectDraw, a deprecated piece of technology from a bygone era. A patch to circumvent DirectDraw is in development.
+**Q&A** \
+Q: Help, I'm getting MSVCP140.dll errors! \
+A: Install vc_redist.x86.exe ( https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads ). \
+ \
+Q: How to update Submarine Titans to version 1.1? \
+A: https://steamcommunity.com/sharedfiles/filedetails/?id=2129291420 \
+ \
+Q: Why is the game running so slow? (Steam/Retail only) \
+A: Submarine Titan uses DirectDraw, a deprecated piece of technology from a bygone era. A patch to circumvent DirectDraw is in development. \
 
 **Known bugs**
 * 1366*768 does not function correctly, reverts to 1280x768 ingame.

--- a/shared/gameversion.h
+++ b/shared/gameversion.h
@@ -1,7 +1,7 @@
 #pragma once
 
 namespace Shared {
-	constexpr unsigned long ST_GAMEVERSION_STEAM = 0x004337AC; // 1.0 from steam store/retail
-	constexpr unsigned long ST_GAMEVERSION_STEAM_PATCHED = 0x004232A5; // 1.1 retail patch
-	constexpr unsigned long ST_GAMEVERSION_GOG = 0x004257DB; // 1.1 from gog store
+	constexpr unsigned long ST_GAMEVERSION_STEAM = 0x826D8625; // 1.0 from steam store/retail
+	constexpr unsigned long ST_GAMEVERSION_STEAM_PATCHED = 0xB5BD8D15; // 1.1 retail patch
+	constexpr unsigned long ST_GAMEVERSION_GOG = 0x18C26D0A; // 1.1 from gog store
 }

--- a/shared/shared.vcxproj
+++ b/shared/shared.vcxproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
+    <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>

--- a/subtitans/gogpatcher.cpp
+++ b/subtitans/gogpatcher.cpp
@@ -25,6 +25,8 @@ void GOGPatcher::Configure()
 	nativeResolutionPatch->ScreenResizeHeightAddress = 0x0056D7FF; // 0x0056F03F;
 	nativeResolutionPatch->GamefieldPresetWidthAddress = 0x0056B1CC; //0x0056CA0C;
 	nativeResolutionPatch->GamefieldPresetHeightAddress = 0x0056B1D6; //0x0056CA16;
+	nativeResolutionPatch->GamefieldHeightReducingAddress = 0x004F7057;
+	nativeResolutionPatch->GamefieldHeightRestorationAddress = 0x004FB487;
 	nativeResolutionPatch->MovieWidthAddress = 0x00570515; // 0x00571D55;
 	nativeResolutionPatch->MovieHeightAddress = 0x0057051C; // 0x00571D5C;
 	nativeResolutionPatch->RepositionBottomMenuDetourAddress = 0x004F6814; // 0x004F8084;
@@ -33,6 +35,7 @@ void GOGPatcher::Configure()
 	nativeResolutionPatch->RedesignFrameDetourAddress = 0x00543032; // 0x00544872;
 	nativeResolutionPatch->RedesignFrameTeamIdMemoryAddress = 0x0080874E; // 0x0080911E;
 	nativeResolutionPatch->RedesignFrameDrawFunctionAddress = 0x00403738; //0x0040372E;
+	nativeResolutionPatch->RepositionBriefingDetourAddress = 0x004F6AB2;
 	_patches.push_back(nativeResolutionPatch);
 
 	auto sleepWellPatch = new SleepWellPatch();

--- a/subtitans/nativeresolutionpatch.h
+++ b/subtitans/nativeresolutionpatch.h
@@ -24,6 +24,9 @@ public:
 	unsigned long GamefieldPresetWidthAddress;
 	unsigned long GamefieldPresetHeightAddress;
 
+	unsigned long GamefieldHeightReducingAddress;
+	unsigned long GamefieldHeightRestorationAddress;
+
 	unsigned long MovieWidthAddress;
 	unsigned long MovieHeightAddress;
 
@@ -33,4 +36,5 @@ public:
 	unsigned long RedesignFrameDetourAddress;
 	unsigned long RedesignFrameTeamIdMemoryAddress;
 	unsigned long RedesignFrameDrawFunctionAddress;
+	unsigned long RepositionBriefingDetourAddress;
 };

--- a/subtitans/steampatchedpatcher.cpp
+++ b/subtitans/steampatchedpatcher.cpp
@@ -35,6 +35,8 @@ void SteamPatchedPatcher::Configure()
 	nativeResolutionPatch->ScreenResizeHeightAddress = 0x0056D7FF; // 0x0056F03F;
 	nativeResolutionPatch->GamefieldPresetWidthAddress = 0x0056B1CC; //0x0056CA0C;
 	nativeResolutionPatch->GamefieldPresetHeightAddress = 0x0056B1D6; //0x0056CA16;
+	nativeResolutionPatch->GamefieldHeightReducingAddress = 0x004F7057;
+	nativeResolutionPatch->GamefieldHeightRestorationAddress = 0x004FB487;
 	nativeResolutionPatch->MovieWidthAddress = 0x00570515; // 0x00571D55;
 	nativeResolutionPatch->MovieHeightAddress = 0x0057051C; // 0x00571D5C;
 	nativeResolutionPatch->RepositionBottomMenuDetourAddress = 0x004F6814; // 0x004F8084;
@@ -43,6 +45,7 @@ void SteamPatchedPatcher::Configure()
 	nativeResolutionPatch->RedesignFrameDetourAddress = 0x00543032; // 0x00544872;
 	nativeResolutionPatch->RedesignFrameTeamIdMemoryAddress = 0x0080874E; // 0x0080911E;
 	nativeResolutionPatch->RedesignFrameDrawFunctionAddress = 0x00403738; //0x0040372E;
+	nativeResolutionPatch->RepositionBriefingDetourAddress = 0x004F6AB2;
 	_patches.push_back(nativeResolutionPatch);
 
 	auto highDPIPatch = new HighDPIPatch();

--- a/subtitans/steampatcher.cpp
+++ b/subtitans/steampatcher.cpp
@@ -151,6 +151,8 @@ void SteamPatcher::Configure()
 	nativeResolutionPatch->ScreenResizeHeightAddress = 0x0056F03F;
 	nativeResolutionPatch->GamefieldPresetWidthAddress = 0x0056CA0C;
 	nativeResolutionPatch->GamefieldPresetHeightAddress = 0x0056CA16;
+	nativeResolutionPatch->GamefieldHeightReducingAddress = 0x004F88C7;
+	nativeResolutionPatch->GamefieldHeightRestorationAddress = 0x004FCCF7;
 	nativeResolutionPatch->MovieWidthAddress = 0x00571D55;
 	nativeResolutionPatch->MovieHeightAddress = 0x00571D5C;
 	nativeResolutionPatch->RepositionBottomMenuDetourAddress = 0x004F8084;
@@ -159,6 +161,7 @@ void SteamPatcher::Configure()
 	nativeResolutionPatch->RedesignFrameDetourAddress = 0x00544872;
 	nativeResolutionPatch->RedesignFrameTeamIdMemoryAddress = 0x0080911E;
 	nativeResolutionPatch->RedesignFrameDrawFunctionAddress = 0x0040372E;
+	nativeResolutionPatch->RepositionBriefingDetourAddress = 0x004F8322;
 	_patches.push_back(nativeResolutionPatch);
 
 	auto highDPIPatch = new HighDPIPatch();

--- a/subtitans/subtitans.cpp
+++ b/subtitans/subtitans.cpp
@@ -27,7 +27,7 @@ extern "C" void __stdcall InitializeLibrary(unsigned long gameVersion)
 		case Shared::ST_GAMEVERSION_STEAM:
 			g_GamePatcher = new SteamPatcher();
 			GetLogger()->Informational("Version: Steam (1.0)\n");
-			GetLogger()->Warning("Consider updating to 1.1\n");
+			GetLogger()->Warning("DEPRECATED!!! Consider updating to 1.1\n");
 			break;
 		case Shared::ST_GAMEVERSION_STEAM_PATCHED:
 			g_GamePatcher = new SteamPatchedPatcher();
@@ -70,6 +70,9 @@ extern "C" void __stdcall ReleaseLibrary()
 
 	if (g_GamePatcher)
 		delete g_GamePatcher;
+
+	if (g_Logger)
+		delete g_Logger;
 }
 
 BOOLEAN __stdcall DllMain(HINSTANCE handle, DWORD reason, LPVOID reserved)

--- a/subtitans/subtitans.h
+++ b/subtitans/subtitans.h
@@ -3,6 +3,8 @@
 #include <Windows.h>
 #include <windowsx.h>
 #include <cmath>
+#include <cstdint>
+#include <vector>
 
 #pragma comment(lib, "winmm.lib")
 


### PR DESCRIPTION
Remove non kernel32 call from dllmain 
Use CRC32 to determine game version
Fix compilation of shared when build as debug
Reposition (center) ingame briefing
Draw parts of the map instead of void next to the ingame command panel
Update README.md